### PR TITLE
fix: enforce tag limit for closing tickets to prevent exceeding maximum limit

### DIFF
--- a/services/discord/commands/close.ts
+++ b/services/discord/commands/close.ts
@@ -14,7 +14,7 @@ export const closeTicketLogic = async (
   thread: ThreadChannel,
   description?: string,
   closedOn?: string,
-  userId?: string,
+  userId?: string
 ) => {
   const firstMessage = await thread.fetchStarterMessage();
   const threadId = thread.id;
@@ -33,6 +33,11 @@ export const closeTicketLogic = async (
   const resolvedTag = tags.find((tag) => tag.name === "Resolved");
 
   if (resolvedTag && !currentTags.includes(resolvedTag.id)) {
+    if (currentTags.length >= 5) {
+      throw new Error(
+        "Cannot close ticket: this thread has too many tags applied. Applied tags should not be greater than 4 to allow adding the 'Resolved' tag. Please remove a tag and try again."
+      );
+    }
     await thread.setAppliedTags([...currentTags, resolvedTag.id]);
   }
   // Prepare values for sheet update
@@ -160,7 +165,7 @@ export const getFeedback = async (interaction: ButtonInteraction) => {
 const storeFeedback = async (
   thread: ThreadChannel,
   rating: number,
-  createdTimestamp: number | null,
+  createdTimestamp: number | null
 ) => {
   const firstMessage = await thread.fetchStarterMessage();
   const writeValues = [
@@ -186,6 +191,6 @@ const storeFeedback = async (
     {
       Rating: rating.toString(),
     },
-    writeValues,
+    writeValues
   );
 };


### PR DESCRIPTION

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord tickets with 5 or more tags can no longer be marked as resolved due to tag limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->