### PR TITLE
fix: remove unused fetchStarterMessage call causing ticket-close crashes

### DIFF
--- a/services/discord/commands/close.ts
+++ b/services/discord/commands/close.ts
@@ -47,7 +47,6 @@ export const recordTicketClosure = async (
 ) => {
   const threadId = thread.id;
   const createdTimestamp = thread.createdTimestamp;
-  const firstMessage = await thread.fetchStarterMessage();
 
   const closureTimeMinutes = dayjs().diff(createdTimestamp, "minute");
   const closedAt = closedOn || dayjs().format("YYYY-MM-DD HH:mm");


### PR DESCRIPTION
## Problem
`/close-ticket` was crashing with `DiscordAPIError[10008]: Unknown Message` whenever a forum thread's starter message had been deleted (thread still exists, but the original post doesn't). This happened inside
`recordTicketClosure`, which called `thread.fetchStarterMessage()` and never even used the result (`firstMessage` was assigned but never read anywhere else in the function).

Because the crash happened at the very start of `recordTicketClosure`, the whole closure flow aborted — the sheet was never updated, the rating buttons were never posted, and the user just saw a generic error instead
of a properly closed ticket.

## Fix
Removed the dead `const firstMessage = await thread.fetchStarterMessage();` line. It had no downstream use, so dropping it eliminates the crash with no behavior change to the rest of the closure flow.